### PR TITLE
Added DevSpace with VS Code-Server support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,62 @@
+### Ruby ###
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Used by dotenv library to load environment variables.
+# .env
+
+# Ignore Byebug command history file.
+.byebug_history
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+# logs
+log/
+
+# DevSpaces files
 .stfolder
 .stignore
+.stversions
+buildspec.yml

--- a/devspace/Dockerfile
+++ b/devspace/Dockerfile
@@ -1,6 +1,6 @@
-# DOCKER FILE 
+# DOCKER FILE
 
-FROM ruby:latest
+FROM ruby:2.6.2
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
 && apt-get install -y mysql-server mysql-client default-libmysqlclient-dev vim nodejs --no-install-recommends \

--- a/devspace/code-server/Dockerfile
+++ b/devspace/code-server/Dockerfile
@@ -1,0 +1,39 @@
+FROM ruby:2.6.2
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update \
+  && apt-get install -y \
+    mysql-server \
+    mysql-client \
+    default-libmysqlclient-dev \
+    vim \
+    nodejs \
+    wget \
+    locales \
+    --no-install-recommends \
+  && apt-get clean \
+  && sed -i -e 's/bind-address/#bind-address/g' /etc/mysql/mariadb.conf.d/50-server.cnf \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN locale-gen en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+ENV CODE_SERVER_VER=1.1119-vsc1.33.1
+
+# Download code-server to /opt
+RUN wget "https://github.com/cdr/code-server/releases/download/${CODE_SERVER_VER}/code-server${CODE_SERVER_VER}-linux-x64.tar.gz" \
+    -P /opt/ \
+  && tar -xvzf "/opt/code-server${CODE_SERVER_VER}-linux-x64.tar.gz" -C /opt \
+  && rm -f "/opt/code-server${CODE_SERVER_VER}-linux-x64.tar.gz" \
+  && mv "/opt/code-server${CODE_SERVER_VER}-linux-x64" /opt/code-server-linux
+
+COPY open-remote-connections.sql /tmp
+COPY entrypoint.sh /usr/local/bin/
+
+RUN gem install rails -v '5.2.2' \
+  && chmod +x /usr/local/bin/entrypoint.sh
+
+WORKDIR /data
+
+ENTRYPOINT ["entrypoint.sh"]
+CMD tail -f /dev/null

--- a/devspace/code-server/devspaces.yml
+++ b/devspace/code-server/devspaces.yml
@@ -1,0 +1,50 @@
+--- # devspaces.yml
+name: ruby-code-server-demo
+description: RoR dev environment using code-server.
+
+# If you want to use a different Dockerfile for your DevSpace, provide the path
+# here.
+docker-file: Dockerfile
+
+# If you need additional files when building your Dockerfile, such as some
+# application binaries that your Dockerfile references, list the glob paths to
+# include here. They are relative to this devspaces.yml file.
+docker-build-includes: |
+  **/*
+  ../open-remote-connections.sql
+
+ports:
+  - protocol: http # can be udp|tcp|http
+    port-number: 3000
+    description: web app http port
+  - protocol: tcp
+    port-number: 3306
+    description: mysql port
+  - protocol: http
+    port-number: 8443
+    description: code-server port
+
+#
+# Any environment variable specified here is injected into the build and/or
+# runtime environment of the Docker container.
+# The *Shared* flag determines if the value of the environment variable is shared
+#   when this DevSpace is shared with others. The default is to share environment
+#   variable values. If there is a value that should be set differently by every
+#   developer that the DevSpace is shared with then Shared should be set to No.
+#   An example of a value not to share is an API key that every developer generates
+#   for themselves.
+# The *Scope* enum determines if the environment variable is used at buildtime
+# (docker build), runtime (docker run) or both. The acceptable values are 'run',
+# 'build' and 'all'. If unspecified, scope is 'all' by default.
+environment-vars:
+
+# When you bind your DevSpace to a local directory, the files will be synchronized
+# betewen your workstation and the /data directory in your DevSpace container.
+# If there are files that should not be synced, such as large objects or logs,
+# configure an ignore directive here
+sync-ignore: |
+  .git
+  .idea
+  **/node_modules
+  .DS_Store
+  .data

--- a/devspace/code-server/entrypoint.sh
+++ b/devspace/code-server/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+/etc/init.d/mysql start
+mysql < /tmp/open-remote-connections.sql
+
+# Start code-server
+/opt/code-server-linux/code-server --no-auth /data
+
+exec "$@"


### PR DESCRIPTION
  created a new DevSpace configuration that has VS code-server (https://github.com/cdr/code-server) installed. This allows code editing directly from the browser

**Other changes**
    - updated Dockerfile to use ruby version 2.6.2 to match the version specified in Gemfile
    - improved `.gitignore` file